### PR TITLE
Fix: command gave following error:

### DIFF
--- a/docs/platform/local-development/set-up-frontend-environment.md
+++ b/docs/platform/local-development/set-up-frontend-environment.md
@@ -35,7 +35,7 @@ $ npm install
 1. To get the OpenAPI specs locally, run:
 
 ```shell
-$ npm openapi
+$ npm run openapi
 ```
 
 1. Now you are ready to start the application, run:


### PR DESCRIPTION
Unknown command: "openapi"

Did you mean this?
    npm run openapi # run the "openapi" package script